### PR TITLE
Switching JsonUtils reader/writer for UTF-16 reader/writer

### DIFF
--- a/src/main/java/fi/dy/masa/malilib/util/JsonUtils.java
+++ b/src/main/java/fi/dy/masa/malilib/util/JsonUtils.java
@@ -1,8 +1,11 @@
 package fi.dy.masa.malilib.util;
 
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -441,7 +444,7 @@ public class JsonUtils
             try
             {
                 JsonParser parser = new JsonParser();
-                FileReader reader = new FileReader(file);
+                InputStreamReader reader = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_16);
 
                 JsonElement element = parser.parse(reader);
                 reader.close();
@@ -477,7 +480,7 @@ public class JsonUtils
 
     public static boolean writeJsonToFile(Gson gson, JsonElement root, File file)
     {
-        FileWriter writer = null;
+        OutputStreamWriter writer = null;
         File fileTmp = new File(file.getParentFile(), file.getName() + ".tmp");
 
         if (fileTmp.exists())
@@ -487,7 +490,7 @@ public class JsonUtils
 
         try
         {
-            writer = new FileWriter(fileTmp);
+            writer = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_16);
             writer.write(gson.toJson(root));
             writer.close();
 

--- a/src/main/java/fi/dy/masa/malilib/util/JsonUtils.java
+++ b/src/main/java/fi/dy/masa/malilib/util/JsonUtils.java
@@ -444,7 +444,7 @@ public class JsonUtils
             try
             {
                 JsonParser parser = new JsonParser();
-                InputStreamReader reader = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_16);
+                InputStreamReader reader = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8);
 
                 JsonElement element = parser.parse(reader);
                 reader.close();
@@ -490,7 +490,7 @@ public class JsonUtils
 
         try
         {
-            writer = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_16);
+            writer = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
             writer.write(gson.toJson(root));
             writer.close();
 


### PR DESCRIPTION
[FileReader](https://docs.oracle.com/javase/7/docs/api/java/io/FileReader.html) and [FileWriter](https://docs.oracle.com/javase/7/docs/api/java/io/FileWriter.html) use default character encoding and decoding. On Window's systems the default is UTF-8 and on Unix based the default is UTF-16. Since Minecraft uses UTF-16, characters that the players put in a configuration text box may not be properly kept depending on their operating system. This pull request enforces UTF-16 for JsonUtils.