### PR TITLE
Remove deprecation warning

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -36,6 +36,8 @@
   },
 
   "custom": {
-    "modmenu:api": true
+    "modmenu": {
+      "badges": [ "library" ]
+    }
   }
 }


### PR DESCRIPTION
The old API is deprecated. I am aware that #41 exists, but that is PRing to a different branch, and also fails to account for this mod being a library.