### PR TITLE
disable depth test and depth mask for every line, not just the first

### DIFF
--- a/src/main/java/fi/dy/masa/malilib/render/RenderUtils.java
+++ b/src/main/java/fi/dy/masa/malilib/render/RenderUtils.java
@@ -804,6 +804,8 @@ public class RenderUtils
         {
             if (disableDepth)
             {
+                RenderSystem.depthMask(false);
+                RenderSystem.disableDepthTest();
                 VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(buffer);
                 textRenderer.draw(line, -strLenHalf, textY, 0x20000000 | (textColor & 0xFFFFFF), false, modelMatrix, immediate, true, 0, 15728880);
                 immediate.draw();


### PR DESCRIPTION
For multi-line text plates only the first line is visible through blocks.