### PR TITLE
Fix config category search not working with upper case

### DIFF
--- a/src/main/java/fi/dy/masa/malilib/gui/widgets/WidgetListConfigOptions.java
+++ b/src/main/java/fi/dy/masa/malilib/gui/widgets/WidgetListConfigOptions.java
@@ -71,7 +71,7 @@ public class WidgetListConfigOptions extends WidgetListConfigOptionsBase<ConfigO
     {
         if (this.widgetSearchConfigs != null)
         {
-            String filterText = this.widgetSearchConfigs.getFilter();
+            String filterText = this.widgetSearchConfigs.getFilter().toLowerCase();
             IKeybind filterKeys = this.widgetSearchConfigs.getKeybind();
 
             for (ConfigOptionWrapper entry : entries)


### PR DESCRIPTION
Configuration categories that contain Keybinds don't work with search strings that contain upper-case characters. Example: Litematica's Hotkeys, Tweakaroo's Tweaks, Hotkeys, and Yeets.

In Tweakaroo, searching for ```tweakAccurateBlockPlacement``` in the Tweaks category yields nothing, while searching for ```tweakaccurateblockplacement``` gives the correct result.

WidgetListBase's getFilterText() converts the search bar filter to lower case,
```java
    protected String getFilterText()
    {
        return this.widgetSearchBar != null ? this.widgetSearchBar.getFilter().toLowerCase() : "";
    }
```

where WidgetListConfigOptions's getFilterText() does not when widgetSearchConfigs is not null.
```java
    @Override
    protected void addFilteredContents(Collection<ConfigOptionWrapper> entries)
    {
        if (this.widgetSearchConfigs != null)
        {
            String filterText = this.widgetSearchConfigs.getFilter(); // should be lower case here
            IKeybind filterKeys = this.widgetSearchConfigs.getKeybind();

            for (ConfigOptionWrapper entry : entries)
            {
                if ((filterText.isEmpty() || this.entryMatchesFilter(entry, filterText)) &&
                    (entry.getConfig().getType() != ConfigType.HOTKEY ||
                     filterKeys.getKeys().size() == 0 ||
                     ((IHotkey) entry.getConfig()).getKeybind().overlaps(filterKeys)))
                {
                    this.listContents.add(entry);
                }
            }
        }
        else
        {
            super.addFilteredContents(entries);
        }
    }
```