### PR TITLE
Add "library" modmenu badge as this is a library mod.

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,6 +27,11 @@
 			"fi.dy.masa.malilib.compat.modmenu.ModMenuImpl"
 		]
 	},
+	"custom": {
+		"modmenu": {
+			"badges": [ "library" ]
+		}
+	},
 	"mixins": [
 		"mixins.malilib.json"
 	],


### PR DESCRIPTION
Very simple addition to the `fabric.mod.json`. Useful when using modmenu's options to filter by mod type.