### PR TITLE
Fix ConfigColorList falsely prompting resets for values that haven't changed

### DIFF
--- a/src/main/java/fi/dy/masa/malilib/util/Color4f.java
+++ b/src/main/java/fi/dy/masa/malilib/util/Color4f.java
@@ -65,6 +65,27 @@ public class Color4f
         return new Color4f(r, g, b, alpha);
     }
 
+    @Override
+    public boolean equals(Object obj) 
+    {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (this.getClass() != obj.getClass())
+            return false;
+
+        Color4f other = (Color4f) obj;
+
+        return intValue == other.intValue;
+    }
+
+    @Override
+    public int hashCode() 
+    {
+        return Objects.hash(intValue);
+    }
+
     public String toHexString()
     {
         return String.format("#%08X", intValue);


### PR DESCRIPTION
Overrides equals() and hashcode() in Color4f to correctly save the default values