### PR TITLE
Ornithe gen1 bugfixes

### DIFF
--- a/src/main/java/malilib/gui/BaseScreen.java
+++ b/src/main/java/malilib/gui/BaseScreen.java
@@ -1092,17 +1092,17 @@ public abstract class BaseScreen extends GuiScreen
 
     public static boolean isShiftDown()
     {
-        return isShiftKeyDown();
+        return GuiScreen.isShiftKeyDown();
     }
 
     public static boolean isCtrlDown()
     {
-        return isCtrlKeyDown();
+        return GuiScreen.isCtrlKeyDown();
     }
 
     public static boolean isAltDown()
     {
-        return isAltKeyDown();
+        return GuiScreen.isAltKeyDown();
     }
 
     public static void setStringToClipboard(String str)

--- a/src/main/java/malilib/render/inventory/InventoryRenderUtils.java
+++ b/src/main/java/malilib/render/inventory/InventoryRenderUtils.java
@@ -503,19 +503,31 @@ public class InventoryRenderUtils
     public static Pair<InventoryView, InventoryRenderDefinition> getPointedInventory()
     {
         World world = WorldWrap.getBestWorld();
+        Entity cameraEntity = GameWrap.getCameraEntity();
         EntityPlayer clientPlayer = GameWrap.getClientPlayer();
 
-        // We need to get the player from the server world,
-        // so that the player itself won't be included in the ray trace
-        EntityPlayer player = world.getPlayerEntityByUUID(EntityWrap.getUuid(clientPlayer));
-
-        if (player == null)
+        if (cameraEntity == clientPlayer && world instanceof WorldServer)
         {
-            player = clientPlayer;
+            // We need to get the player from the server world,
+            // so that the player itself won't be included in the ray trace
+            EntityPlayer player = world.getPlayerEntityByUUID(EntityWrap.getUuid(clientPlayer));
+
+            if (player == null)
+            {
+                cameraEntity = player;
+            }
         }
 
         RayTraceUtils.RayTraceFluidHandling fluidHandling = RayTraceUtils.RayTraceFluidHandling.NONE;
-        HitResult trace = RayTraceUtils.getRayTraceFromEntity(world, player, fluidHandling, true, 6.0);
+        HitResult trace;
+        if (cameraEntity != clientPlayer)
+        {
+            trace = RayTraceUtils.getRayTraceFromEntity(world, cameraEntity, fluidHandling, true, 6.0);
+        }
+        else
+        {
+            trace = GameWrap.getHitResult();
+        }
 
         if (trace == null)
         {


### PR DESCRIPTION
- [fix super call in BaseScreen](https://github.com/maruohon/malilib/commit/172b9426d104d4aae372e514d1c0c6e058105f36): this currently causes a stack overflow crash in any feather mods using malilib, since `isShiftDown` is called `isShiftKeyDown` etc. in feather. I think you mentioned you wanted to move these out of `BaseScreen`, but this fixes it for now.

- [getPointedInventory from cameraEntity instead of player](https://github.com/maruohon/malilib/commit/1e43160120234b1deac8255a0268c57c022d5297): this changes the method to match pre-rewrite Tweakeroo's [implementation](https://github.com/sakura-ryoko/tweakeroo/blob/fa6f81c0dac69d06b9a7f210da67fdc00641d89f/src/main/java/fi/dy/masa/tweakeroo/renderer/InventoryOverlayHandler.java#L141), and allows freecam to target chests.

- [add GeometryResizeNotifier for viewport size to InfoOverlay](https://github.com/maruohon/malilib/commit/13b802f996897ae07b5d346099649f4de21d62b8): add a window resize check. Currently, info lines and C.S.I. don't change positions when the window is resized unless they are activated/deactivated.